### PR TITLE
feat: make ATCR namespace configurable via secret

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
-  ATCR_IMAGE: atcr.io/slices.network/quickslice
+  ATCR_IMAGE: atcr.io/${{ secrets.ATCR_NAMESPACE }}/quickslice
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Allows forks and the main repo to use different ATCR namespaces by setting the `ATCR_NAMESPACE` secret in repository settings.

Required secrets:
- `ATCR_NAMESPACE` - the namespace on atcr.io (e.g., `slices.network`)
- `ATCR_USERNAME` - ATCR username
- `ATCR_PASSWORD` - ATCR password/token

**NOTE:** This PR isn't strictly necessary. It's just a nice update for those of us contributing that can benefit from being able to build our own forks of the app.