### PR TITLE
fix: update dbmate to v2.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,13 @@ RUN cd /build/server \
 FROM ghcr.io/gleam-lang/gleam:${GLEAM_VERSION}-erlang-alpine
 
 # Install runtime dependencies and dbmate for migrations
+# NOTE: Pinned to v2.29.3 because v2.29.4+ has a regression causing EOF errors
+# with Supabase connection pooler. See: https://github.com/amacneil/dbmate/issues/746
 ARG TARGETARCH
+ARG DBMATE_VERSION=v2.29.3
 RUN apk add --no-cache sqlite-libs sqlite libpq curl \
     && DBMATE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
-    && curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/latest/download/dbmate-linux-${DBMATE_ARCH} \
+    && curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/${DBMATE_VERSION}/dbmate-linux-${DBMATE_ARCH} \
     && chmod +x /usr/local/bin/dbmate
 
 # Copy the compiled server code from the builder stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,8 @@ RUN cd /build/server \
 FROM ghcr.io/gleam-lang/gleam:${GLEAM_VERSION}-erlang-alpine
 
 # Install runtime dependencies and dbmate for migrations
-# NOTE: Pinned to v2.29.3 because v2.29.4+ has a regression causing EOF errors
-# with Supabase connection pooler. See: https://github.com/amacneil/dbmate/issues/746
 ARG TARGETARCH
-ARG DBMATE_VERSION=v2.29.3
+ARG DBMATE_VERSION=v2.30.0
 RUN apk add --no-cache sqlite-libs sqlite libpq curl \
     && DBMATE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") \
     && curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/${DBMATE_VERSION}/dbmate-linux-${DBMATE_ARCH} \


### PR DESCRIPTION
## Summary
- Update dbmate from v2.29.3 to v2.30.0

## Context
dbmate v2.29.4+ had a regression causing EOF errors with Supabase's connection pooler ([#746](https://github.com/amacneil/dbmate/issues/746)). We pinned to v2.29.3 as a workaround. The fix has now been released in v2.30.0, so we can upgrade.

## Test plan
- [ ] Verify migrations run successfully on Railway with the new version