### PR TITLE
Parallelize multi-platform Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,12 +10,18 @@ env:
   ATCR_IMAGE: atcr.io/slices.network/quickslice
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
 
     steps:
       - name: Checkout repository
@@ -47,6 +53,72 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.ATCR_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=build-${{ matrix.platform }}
+          cache-to: type=gha,scope=build-${{ matrix.platform }},mode=max
+          outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.ATCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to ATCR
+        uses: docker/login-action@v3
+        with:
+          registry: atcr.io
+          username: ${{ secrets.ATCR_USERNAME }}
+          password: ${{ secrets.ATCR_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.ATCR_IMAGE }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -56,13 +128,22 @@ jobs:
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
+
+      - name: Create ATCR manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Extract only ATCR tags from metadata
+          ATCR_TAGS=$(jq -cr '.tags | map(select(startswith("atcr.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          if [ -n "$ATCR_TAGS" ]; then
+            docker buildx imagetools create $ATCR_TAGS \
+              $(printf '${{ env.ATCR_IMAGE }}@sha256:%s ' *)
+          fi
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,28 +15,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache client build
+        id: client-cache
+        uses: actions/cache@v4
+        with:
+          path: build/static
+          key: client-static-${{ hashFiles('client/**') }}
+
       - uses: erlef/setup-beam@v1
+        if: steps.client-cache.outputs.cache-hit != 'true'
         with:
           otp-version: "28"
           gleam-version: "1.13.0"
           rebar3-version: "3"
 
       - uses: actions/setup-node@v4
+        if: steps.client-cache.outputs.cache-hit != 'true'
         with:
           node-version: "18"
 
       - name: Install Bun
+        if: steps.client-cache.outputs.cache-hit != 'true'
         run: npm install -g bun
 
       - name: Download Gleam dependencies
+        if: steps.client-cache.outputs.cache-hit != 'true'
         working-directory: client
         run: gleam deps download
 
       - name: Install npm dependencies
+        if: steps.client-cache.outputs.cache-hit != 'true'
         working-directory: client
         run: npm install
 
       - name: Build client
+        if: steps.client-cache.outputs.cache-hit != 'true'
         working-directory: client
         run: gleam run -m lustre/dev build quickslice_client --minify --outdir=../build/static
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,8 +10,41 @@ env:
   ATCR_IMAGE: atcr.io/${{ secrets.ATCR_NAMESPACE }}/quickslice
 
 jobs:
+  build-client:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "28"
+          gleam-version: "1.13.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Download Gleam dependencies
+        working-directory: client
+        run: gleam deps download
+
+      - name: Install npm dependencies
+        working-directory: client
+        run: npm install
+
+      - name: Build client
+        working-directory: client
+        run: gleam run -m lustre/dev build quickslice_client --minify --outdir=../build/static
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: client-static
+          path: build/static/
+          retention-days: 1
+
   build:
     runs-on: ubuntu-latest
+    needs: build-client
     permissions:
       contents: read
       packages: write
@@ -26,6 +59,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Download client artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: client-static
+          path: build/static
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           otp-version: "28"
           gleam-version: "1.13.0"
+          rebar3-version: "3"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Install Bun
+        run: npm install -g bun
+
       - name: Download Gleam dependencies
         working-directory: client
         run: gleam deps download

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
-  ATCR_IMAGE: atcr.io/slices.network/quickslice
+  ATCR_IMAGE: atcr.io/${{ secrets.ATCR_NAMESPACE }}/quickslice
 
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -133,6 +133,8 @@ jobs:
         run: |
           GHCR_TAGS=$(jq -cr '.tags | map(select(startswith("ghcr.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           docker buildx imagetools create --append $GHCR_TAGS \
+            ${{ env.GHCR_IMAGE }}@${{ steps.build.outputs.digest }} 2>/dev/null || \
+          docker buildx imagetools create $GHCR_TAGS \
             ${{ env.GHCR_IMAGE }}@${{ steps.build.outputs.digest }}
 
       - name: Create ATCR manifest
@@ -140,5 +142,7 @@ jobs:
           ATCR_TAGS=$(jq -cr '.tags | map(select(startswith("atcr.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -n "$ATCR_TAGS" ]; then
             docker buildx imagetools create --append $ATCR_TAGS \
+              ${{ env.ATCR_IMAGE }}@${{ steps.build.outputs.digest }} 2>/dev/null || \
+            docker buildx imagetools create $ATCR_TAGS \
               ${{ env.ATCR_IMAGE }}@${{ steps.build.outputs.digest }}
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -109,6 +109,14 @@ jobs:
           images: |
             ${{ env.GHCR_IMAGE }}
             ${{ env.ATCR_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push by digest
         id: build
@@ -121,85 +129,16 @@ jobs:
           cache-to: type=gha,scope=build-${{ matrix.platform }},mode=max
           outputs: type=image,"name=${{ env.GHCR_IMAGE }},${{ env.ATCR_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
 
-      - name: Export digest
+      - name: Create GHCR manifest
         run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          GHCR_TAGS=$(jq -cr '.tags | map(select(startswith("ghcr.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create --append $GHCR_TAGS \
+            ${{ env.GHCR_IMAGE }}@${{ steps.build.outputs.digest }}
 
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to ATCR
-        uses: docker/login-action@v3
-        with:
-          registry: atcr.io
-          username: ${{ secrets.ATCR_USERNAME }}
-          password: ${{ secrets.ATCR_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.ATCR_IMAGE }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
+      - name: Create ATCR manifest
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.GHCR_IMAGE }}@sha256:%s ' *)
-
-      - name: Create ATCR manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          # Extract only ATCR tags from metadata
           ATCR_TAGS=$(jq -cr '.tags | map(select(startswith("atcr.io"))) | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           if [ -n "$ATCR_TAGS" ]; then
-            docker buildx imagetools create $ATCR_TAGS \
-              $(printf '${{ env.ATCR_IMAGE }}@sha256:%s ' *)
+            docker buildx imagetools create --append $ATCR_TAGS \
+              ${{ env.ATCR_IMAGE }}@${{ steps.build.outputs.digest }}
           fi
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,42 +7,33 @@ FROM ghcr.io/gleam-lang/gleam:${GLEAM_VERSION}-erlang-alpine AS builder
 RUN apk add --no-cache \
     bash \
     git \
-    nodejs \
-    npm \
     build-base \
     sqlite-dev \
-    postgresql-dev \
-    && npm install -g bun
+    postgresql-dev
 
 # Configure git for non-interactive use
 ENV GIT_TERMINAL_PROMPT=0
 
-# Add local dependencies first (these change less frequently)
-COPY ./lexicon_graphql /build/lexicon_graphql
-COPY ./client /build/client
-COPY ./atproto_car /build/atproto_car
+# Copy only dependency manifests first (these change infrequently)
+COPY ./lexicon_graphql/gleam.toml ./lexicon_graphql/manifest.toml /build/lexicon_graphql/
+COPY ./atproto_car/gleam.toml ./atproto_car/manifest.toml /build/atproto_car/
+COPY ./server/gleam.toml ./server/manifest.toml /build/server/
 
-# Add server code
-COPY ./server /build/server
-
-# Add patches directory
-COPY ./patches /build/patches
-
-# Install dependencies for all projects
-RUN cd /build/client && gleam deps download
+# Download Gleam dependencies (cached unless manifests change)
 RUN cd /build/lexicon_graphql && gleam deps download
 RUN cd /build/server && gleam deps download
 
-# Apply patches to dependencies
+# Copy patches and apply (before full source copy so patch layer is cached)
+COPY ./patches /build/patches
 RUN cd /build && patch -p1 < patches/mist-websocket-protocol.patch
 
-# Install JavaScript dependencies for client
-RUN cd /build/client && npm install
+# Now copy full source code
+COPY ./lexicon_graphql /build/lexicon_graphql
+COPY ./atproto_car /build/atproto_car
+COPY ./server /build/server
 
-# Compile the client code and output to server's static directory
-RUN cd /build/client \
-    && gleam add --dev lustre_dev_tools \
-    && gleam run -m lustre/dev build quickslice_client --minify --outdir=/build/server/priv/static
+# Pre-built client assets
+COPY ./build/static /build/server/priv/static
 
 # Compile the server code
 RUN cd /build/server \


### PR DESCRIPTION
Splits the single sequential Docker build into a matrix strategy that builds amd64 and arm64 in parallel, then merges manifests in a separate job.

- Per-platform GHA cache scoping so builds don't clobber each other
- Digests uploaded as artifacts and assembled into multi-arch manifests for both GHCR and ATCR

## Test plan

- [x] Tested on fork — `v0.20.3-dev.5` built and pushed successfully